### PR TITLE
FSOS: Properly handle setting the default native vlan

### DIFF
--- a/pkg/vendors/fsos/interfaces.go
+++ b/pkg/vendors/fsos/interfaces.go
@@ -82,8 +82,10 @@ func (fs *FSOS) ConfigureInterface(update *models.UpdateInterface) (bool, error)
 		commands = append(commands, fmt.Sprintf("description %s", *update.Description)) // set interface description
 	}
 
-	if update.UntaggedVLAN != nil {
+	if update.UntaggedVLAN != nil && *update.UntaggedVLAN != 1 {
 		commands = append(commands, fmt.Sprintf("switchport trunk native vlan %d", *update.UntaggedVLAN)) // set untagged vlan
+	} else if update.UntaggedVLAN != nil && *update.UntaggedVLAN == 1 {
+		commands = append(commands, fmt.Sprintf("no switchport trunk native vlan"))
 	}
 
 	if update.TaggedVLANs != nil {

--- a/pkg/vendors/fsos/interfaces.go
+++ b/pkg/vendors/fsos/interfaces.go
@@ -85,7 +85,7 @@ func (fs *FSOS) ConfigureInterface(update *models.UpdateInterface) (bool, error)
 	if update.UntaggedVLAN != nil && *update.UntaggedVLAN != 1 {
 		commands = append(commands, fmt.Sprintf("switchport trunk native vlan %d", *update.UntaggedVLAN)) // set untagged vlan
 	} else if update.UntaggedVLAN != nil && *update.UntaggedVLAN == 1 {
-		commands = append(commands, fmt.Sprintf("no switchport trunk native vlan"))
+		commands = append(commands, "no switchport trunk native vlan")
 	}
 
 	if update.TaggedVLANs != nil {


### PR DESCRIPTION
FSOS sets the default vlan implicit, due to that its not possible to set the native vlan to 1, instead the native vlan needs to be unset